### PR TITLE
Fixes deprecation warning  for ArrayAccess on JoinColumnMapping

### DIFF
--- a/Extension/EagerLoadingExtension.php
+++ b/Extension/EagerLoadingExtension.php
@@ -23,6 +23,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\JoinColumnMapping;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
@@ -181,7 +182,7 @@ final class EagerLoadingExtension implements QueryCollectionExtensionInterface, 
                 $associationAlias = $existingJoin->getAlias();
                 $isLeftJoin = Join::LEFT_JOIN === $existingJoin->getJoinType();
             } else {
-                $isNullable = $mapping['joinColumns'][0]?->nullable ?? true;
+                $isNullable = isset($mapping['joinColumns']) && isset($mapping['joinColumns'][0]) ? ($mapping['joinColumns'][0] instanceof JoinColumnMapping ? $mapping['joinColumns'][0]->nullable : $mapping['joinColumns'][0]['nullable']) : true;
                 $isLeftJoin = false !== $wasLeftJoin || true === $isNullable;
                 $method = $isLeftJoin ? 'leftJoin' : 'innerJoin';
 


### PR DESCRIPTION
Using ArrayAccess on Doctrine\ORM\Mapping\JoinColumnMapping is deprecated and will not be possible in Doctrine ORM 4.0. Use the corresponding property instead. (ArrayAccessImplementation.php:31 called by EagerLoadingExtension.php:184, https://github.com/doctrine/orm/pull/11211, package doctrine/orm)

| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
